### PR TITLE
Secure records API with owner based permissions

### DIFF
--- a/oarepo_micro_api/cli.py
+++ b/oarepo_micro_api/cli.py
@@ -23,6 +23,7 @@ from invenio_search import current_search
 from invenio_userprofiles import UserProfile
 
 from oarepo_micro_api.records.api import Record
+from oarepo_micro_api.records.constants import ACL_PREFERRED_SCHEMA
 
 
 def minter(pid_type, pid_field, record):
@@ -92,6 +93,7 @@ class ItemGenerator(Generator):
         size = self.holder.items["total"]
         objs = [
             {
+                "owners": [-1],
                 "pid": self.create_pid(),
                 "identifier": "{}".format(uuid4()),
                 "abstract": [{"lang": random_lang(), "value": lorem.text()}],
@@ -208,6 +210,9 @@ def setup(admin_password, recreate_db, skip_demo_data, skip_file_location, verbo
     # Create files location
     if not skip_file_location:
         run_command("files location --default oarepo /tmp/oarepo")
+
+    # Create ACLs index for preferred SCHEMA
+    run_command("invenio invenio_explicit_acls prepare {}".format(ACL_PREFERRED_SCHEMA))
 
     # Generate demo data
     if not skip_demo_data:

--- a/oarepo_micro_api/records/api.py
+++ b/oarepo_micro_api/records/api.py
@@ -11,8 +11,11 @@ from __future__ import absolute_import, print_function
 
 from invenio_records_files.api import Record as FilesRecord
 
+from oarepo_micro_api.records.constants import ACL_ALLOWED_SCHEMAS, ACL_PREFERRED_SCHEMA
+
 
 class Record(FilesRecord):
-    """Custom record."""
-
+    """ACL enabled Demo Record."""
     _schema = "records/record-v1.0.0.json"
+    ALLOWED_SCHEMAS = ACL_ALLOWED_SCHEMAS
+    PREFERRED_SCHEMA = ACL_PREFERRED_SCHEMA

--- a/oarepo_micro_api/records/config.py
+++ b/oarepo_micro_api/records/config.py
@@ -21,8 +21,8 @@ from invenio_search.api import DefaultFilter
 from oarepo_micro_api.records.api import Record
 from oarepo_micro_api.records.facets import term_facet, title_lang_facet
 from oarepo_micro_api.records.filters import language_aware_match_filter, nested_terms_filter
-from oarepo_micro_api.records.permissions import authenticated_permission_factory, admin_permission_factory,\
-    owner_permission_filter
+from oarepo_micro_api.records.permissions import authenticated_permission_factory, admin_permission_factory, \
+    owner_permission_filter, owner_permission_factory
 
 
 def _(x):
@@ -91,8 +91,8 @@ RECORDS_REST_ENDPOINTS = {
         max_result_window=10000,
         error_handlers=dict(),
         create_permission_factory_imp=authenticated_permission_factory,
-        read_permission_factory_imp=authenticated_permission_factory,
-        update_permission_factory_imp=authenticated_permission_factory,
+        read_permission_factory_imp=owner_permission_factory,
+        update_permission_factory_imp=owner_permission_factory,
         delete_permission_factory_imp=admin_permission_factory,
         list_permission_factory_imp=allow_all,
         links_factory_imp='invenio_records_files.'

--- a/oarepo_micro_api/records/config.py
+++ b/oarepo_micro_api/records/config.py
@@ -10,19 +10,27 @@
 from __future__ import absolute_import, print_function
 
 from elasticsearch_dsl import Q
+from invenio_explicit_acls.acl_records_search import ACLRecordsSearch
 from invenio_indexer.api import RecordIndexer
 from invenio_records_rest.facets import terms_filter
 from invenio_records_rest.query import default_search_factory
-from invenio_records_rest.utils import allow_all, check_elasticsearch
+from invenio_records_rest.utils import allow_all
+from invenio_search import RecordsSearch
+from invenio_search.api import DefaultFilter
 
 from oarepo_micro_api.records.api import Record
 from oarepo_micro_api.records.facets import term_facet, title_lang_facet
 from oarepo_micro_api.records.filters import language_aware_match_filter, nested_terms_filter
+from oarepo_micro_api.records.permissions import authenticated_permission_factory, admin_permission_factory,\
+    owner_permission_filter
 
 
 def _(x):
     """Identity function for string extraction."""
     return x
+
+
+RECORDS_SEARCH_INDEX = 'records-record-v1.0.0'
 
 
 def search_title(qstr=None):
@@ -31,8 +39,18 @@ def search_title(qstr=None):
     return Q()
 
 
+class FilteredRecordsSearch(RecordsSearch):
+    class Meta:
+        index = RECORDS_SEARCH_INDEX
+        doc_types = None
+        default_filter = DefaultFilter(owner_permission_filter)
+
+
 def search_factory(*args, **kwargs):
-    return default_search_factory(*args, query_parser=search_title, **kwargs)
+    return default_search_factory(
+        *args,
+        query_parser=search_title,
+        **kwargs)
 
 
 FILTERS = {
@@ -49,8 +67,9 @@ RECORDS_REST_ENDPOINTS = {
         default_endpoint_prefix=True,
         record_class=Record,
         indexer_class=RecordIndexer,
+        search_class=FilteredRecordsSearch,
         search_factory_imp=search_factory,
-        search_index='records-record-v1.0.0',
+        search_index=RECORDS_SEARCH_INDEX,
         search_type=None,
         record_serializers={
             'application/json': ('oarepo_micro_api.records.serializers'
@@ -71,10 +90,10 @@ RECORDS_REST_ENDPOINTS = {
         default_media_type='application/json',
         max_result_window=10000,
         error_handlers=dict(),
-        create_permission_factory_imp=allow_all,
-        read_permission_factory_imp=check_elasticsearch,
-        update_permission_factory_imp=allow_all,
-        delete_permission_factory_imp=allow_all,
+        create_permission_factory_imp=authenticated_permission_factory,
+        read_permission_factory_imp=authenticated_permission_factory,
+        update_permission_factory_imp=authenticated_permission_factory,
+        delete_permission_factory_imp=admin_permission_factory,
         list_permission_factory_imp=allow_all,
         links_factory_imp='invenio_records_files.'
                           'links:default_record_files_links_factory',
@@ -130,7 +149,7 @@ OAREPO_API_ENDPOINTS_ENABLED = True
 """Enable/disable automatic endpoint registration."""
 
 RECORDS_REST_FACETS = {
-    'records-record-v1.0.0': {
+    RECORDS_SEARCH_INDEX: {
         'aggs': {
             'creator': term_facet('creator.keyword'),
             'lang': title_lang_facet(),
@@ -175,5 +194,5 @@ RECORDS_FILES_REST_ENDPOINTS = {
 """Records files integration."""
 
 FILES_REST_PERMISSION_FACTORY = \
-    'oarepo_micro_api.records.permissions:files_permission_factory'
+    'oarepo_micro_api.records.permissions:admin_permission_factory'
 """Files-REST permissions factory."""

--- a/oarepo_micro_api/records/constants.py
+++ b/oarepo_micro_api/records/constants.py
@@ -1,0 +1,9 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2020 CERN.
+#
+# OARepo Micro API is free software; you can redistribute it and/or modify it under
+# the terms of the MIT License; see LICENSE file for more details.
+
+ACL_ALLOWED_SCHEMAS = ('records/record-v1.0.0.json',)
+ACL_PREFERRED_SCHEMA = 'records/record-v1.0.0.json'

--- a/oarepo_micro_api/records/jsonschemas/records/record-v1.0.0.json
+++ b/oarepo_micro_api/records/jsonschemas/records/record-v1.0.0.json
@@ -10,6 +10,17 @@
     },
     {
       "$ref": "../invenio-v1.0.0.json#/definitions/InvenioRecord"
+    },
+    {
+      "properties": {
+        "owners": {
+          "description": "List of user ids that are owners of record.",
+          "type": "array",
+          "items": {
+            "type": "number"
+          }
+        }
+      }
     }
   ],
   "required": [

--- a/oarepo_micro_api/records/mappings/v7/records/record-v1.0.0.json
+++ b/oarepo_micro_api/records/mappings/v7/records/record-v1.0.0.json
@@ -50,6 +50,9 @@
       }
     ],
     "properties": {
+      "owners": {
+        "type": "integer"
+      },
       "_search": {
         "type": "text",
         "analyzer": "czech"

--- a/oarepo_micro_api/records/marshmallow/json.py
+++ b/oarepo_micro_api/records/marshmallow/json.py
@@ -9,6 +9,7 @@
 
 from __future__ import absolute_import, print_function
 
+from flask_login import current_user
 from invenio_jsonschemas import current_jsonschemas
 from invenio_oarepo_dc.marshmallow import DCObjectSchemaV1Mixin
 from invenio_oarepo_invenio_model.marshmallow import InvenioRecordMetadataSchemaV1Mixin
@@ -16,10 +17,10 @@ from invenio_oarepo_multilingual.marshmallow import MultilingualStringSchemaV1
 from invenio_records_rest.schemas import StrictKeysMixin
 from invenio_records_rest.schemas.fields import GenFunction, \
     PersistentIdentifier
-from marshmallow import fields, missing, INCLUDE
-
+from marshmallow import fields, missing, INCLUDE, pre_load
 
 from oarepo_micro_api.records.api import Record
+from oarepo_micro_api.records.constants import ACL_ALLOWED_SCHEMAS, ACL_PREFERRED_SCHEMA
 
 
 def bucket_from_context(_, context):
@@ -46,11 +47,22 @@ def schema_from_context(_, context):
 class MetadataSchemaV1(InvenioRecordMetadataSchemaV1Mixin,
                        DCObjectSchemaV1Mixin):
     """Schema for the record metadata."""
+    ALLOWED_SCHEMAS = ACL_ALLOWED_SCHEMAS
+    PREFERRED_SCHEMA = ACL_PREFERRED_SCHEMA
+
+    owners = fields.List(fields.Int(), dump_only=True)
     abstract = MultilingualStringSchemaV1(required=True)
     description = MultilingualStringSchemaV1(required=True)
 
+    @pre_load
+    def set_owners(self, in_data, **kwargs):
+        if current_user.is_authenticated:
+            in_data['owners'] = current_user.get_id()
+        return in_data
+
     class Meta:
         unknown = INCLUDE
+
 
 
 class RecordSchemaV1(StrictKeysMixin):

--- a/oarepo_micro_api/records/permissions.py
+++ b/oarepo_micro_api/records/permissions.py
@@ -23,7 +23,8 @@ def admin_permission_factory(obj, action=None):
 
 def owner_permission_factory(record=None):
     """Permissions factory for record owners."""
-    return Permission(UserNeed(record.get('owner')))
+    # TODO: adapt for more owners
+    return Permission(UserNeed(int(record.get('owners')[0])))
 
 
 def owner_permission_filter():

--- a/oarepo_micro_api/records/permissions.py
+++ b/oarepo_micro_api/records/permissions.py
@@ -6,10 +6,30 @@
 # the terms of the MIT License; see LICENSE file for more details.
 
 """Permissions for OARepo Micro API."""
+from elasticsearch_dsl import Q
+from flask_login import current_user
+from flask_principal import UserNeed, RoleNeed
+from invenio_access import Permission, authenticated_user
 
-from invenio_access import Permission, any_user
+
+def authenticated_permission_factory(record=None):
+    return Permission(authenticated_user)
 
 
-def files_permission_factory(obj, action=None):
+def admin_permission_factory(obj, action=None):
     """Permissions factory for buckets."""
-    return Permission(any_user)
+    return Permission(RoleNeed('admin'))
+
+
+def owner_permission_factory(record=None):
+    """Permissions factory for record owners."""
+    return Permission(UserNeed(record.get('owner')))
+
+
+def owner_permission_filter():
+    """Search only in owned or system records."""
+    ids = [-1]
+    cuid = current_user.get_id()
+    if cuid:
+        ids.append(cuid)
+    return Q('terms', owners=ids)

--- a/requirements.in
+++ b/requirements.in
@@ -1,4 +1,4 @@
-oarepo[deploy-es7,heartbeat,models,files,includes]~=3.2.1
+oarepo[deploy-es7,acls,heartbeat,models,files,includes]~=3.2.1
 Babel>=2.4.0
 Flask-BabelEx>=0.9.3
 lxml>=3.5.0,<4.2.6


### PR DESCRIPTION
This secures the [records API](https://invenio.readthedocs.io/en/latest/tutorials/managing-access.html#managing-access) by the following rules:

  1. Everyone is allowed to list and query default, system owned demo records
  2. Authenticated users are allowed to query and list system records + their own records
  3. Only authenticated users are allowed to create records
  4. Only record owners are allowed to update/get record details
  5. Only Invenio admins are allowed to delete records