### PR TITLE
Attachments API support

### DIFF
--- a/oarepo_micro_api/config.py
+++ b/oarepo_micro_api/config.py
@@ -100,6 +100,10 @@ CELERY_BEAT_SCHEDULE = {
         'task': 'invenio_accounts.tasks.clean_session_table',
         'schedule': timedelta(minutes=60),
     },
+    'file-checks': {
+       'task': 'invenio_files_rest.tasks.schedule_checksum_verification',
+       'schedule': timedelta(hours=24),
+    }
 }
 
 # Database
@@ -159,6 +163,8 @@ APP_DEFAULT_SECURE_HEADERS['content_security_policy'] = {
     'font-src': ["'self'", "data:", "https://fonts.gstatic.com",
                  "https://fonts.googleapis.com"],
 }
+
+REST_ENABLE_CORS = True
 
 PROXYIDP_CONFIG = dict(
     base_url='https://login.cesnet.cz/oidc/',

--- a/oarepo_micro_api/records/config.py
+++ b/oarepo_micro_api/records/config.py
@@ -198,5 +198,5 @@ RECORDS_FILES_REST_ENDPOINTS = {
 """Records files integration."""
 
 FILES_REST_PERMISSION_FACTORY = \
-    'oarepo_micro_api.records.permissions:admin_permission_factory'
+    'oarepo_micro_api.records.permissions:files_permission_factory'
 """Files-REST permissions factory."""

--- a/oarepo_micro_api/records/ext.py
+++ b/oarepo_micro_api/records/ext.py
@@ -9,6 +9,7 @@
 
 from __future__ import absolute_import, print_function
 
+from invenio_files_rest.signals import file_deleted, file_uploaded
 from invenio_indexer.signals import before_record_index
 
 from . import config, indexer
@@ -61,3 +62,5 @@ class OARepoMicroAPI(object):
             indexer.indexer_receiver,
             sender=app,
             index="records-record-v1.0.0")
+        file_deleted.connect(update_record_files_async, weak=False)
+        file_uploaded.connect(update_record_files_async, weak=False)

--- a/oarepo_micro_api/records/jsonschemas/records/record-v1.0.0.json
+++ b/oarepo_micro_api/records/jsonschemas/records/record-v1.0.0.json
@@ -13,6 +13,43 @@
     },
     {
       "properties": {
+        "_bucket": {
+          "description": "UUID of the deposit bucket.",
+          "type": "string"
+        },
+        "_files": {
+          "description": "Describe information needed for files in records.",
+          "type": "array",
+          "items": {
+            "description": "Describes the information of a single file in the record.",
+            "properties": {
+              "key": {
+                "description": "Key (filename) of the file.",
+                "type": "string"
+              },
+              "file_id": {
+                "description": "UUID of the FileInstance object.",
+                "type": "string"
+              },
+              "bucket": {
+                "description": "UUID of the bucket to which this file is assigned.",
+                "type": "string"
+              },
+              "checksum": {
+                "description": "Checksum the file. Starts with '<algorithm>:' prefix, e.g.: 'md5:1234abcd...'",
+                "type": "string"
+              },
+              "size": {
+                "description": "Size of the file in bytes.",
+                "type": "integer"
+              },
+              "version_id": {
+                "description": "UUID of the ObjectVersion object.",
+                "type": "string"
+              }
+            }
+          }
+        },
         "owners": {
           "description": "List of user ids that are owners of record.",
           "type": "array",

--- a/oarepo_micro_api/records/mappings/v7/records/record-v1.0.0.json
+++ b/oarepo_micro_api/records/mappings/v7/records/record-v1.0.0.json
@@ -30,6 +30,7 @@
           "tokenizer": "standard",
           "filter": [
             "lowercase",
+            "word_delimiter",
             "czech_stop",
             "czech_stemmer"
           ]

--- a/oarepo_micro_api/records/permissions.py
+++ b/oarepo_micro_api/records/permissions.py
@@ -10,6 +10,10 @@ from elasticsearch_dsl import Q
 from flask_login import current_user
 from flask_principal import UserNeed, RoleNeed
 from invenio_access import Permission, authenticated_user, any_user
+from invenio_files_rest.models import Bucket, ObjectVersion, MultipartObject
+from invenio_files_rest.permissions import permission_factory, BucketRead
+
+from oarepo_micro_api.records.util import record_from_bucket
 
 
 def _get_owners(record):
@@ -46,6 +50,42 @@ def detail_permission_factory(record=None):
     if len(owners) > 0:
         return Permission(UserNeed(int(owners[0])))
     return Permission(any_user)
+
+
+def files_permission_factory(obj, action=None):
+    """Permissions factory for buckets."""
+    _read_actions = [
+        'files-rest-bucket-read',
+        'files-rest-bucket-read-versions',
+        'files-rest-object-read',
+        'files-rest-object-read-version',
+        'files-rest-multipart-read',
+        'files-rest-bucket-listmultiparts'
+    ]
+
+    _modify_actions = [
+        'files-rest-bucket-update',
+        'files-rest-object-delete'
+        'files-rest-object-delete-version',
+        'files-rest-multipart-delete'
+    ]
+
+    actionNeed = permission_factory(obj, action)
+    record = None
+    if isinstance(obj, Bucket):
+        record = record_from_bucket(obj.id)
+    elif isinstance(obj, ObjectVersion):
+        pass
+    elif isinstance(obj, MultipartObject):
+        pass
+
+    for need in actionNeed.explicit_needs:
+        if need.value in _read_actions:
+            return detail_permission_factory(record)
+        elif need.value in _modify_actions:
+            return owner_permission_factory(record)
+
+    return admin_permission_factory(obj, action)
 
 
 def owner_permission_filter(owned_only=False):

--- a/oarepo_micro_api/records/util.py
+++ b/oarepo_micro_api/records/util.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2020 CESNET.
+#
+# OARepo Micro API is free software; you can redistribute it and/or modify it under
+# the terms of the MIT License; see LICENSE file for more details.
+
+"""Utility functions."""
+import sqlalchemy
+from invenio_db import db
+from invenio_records_files.api import Record
+from invenio_records_files.models import RecordsBuckets
+
+
+def record_from_bucket(bucket_id):
+    record_bucket = \
+        RecordsBuckets.query.filter_by(bucket_id=bucket_id).first()
+    if record_bucket:
+        record = Record.get_record(record_bucket.record_id)
+        return record
+    return None

--- a/oarepo_micro_api/tasks.py
+++ b/oarepo_micro_api/tasks.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2020 CESNET.
+#
+# OARepo Micro API is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Tasks for OARepo Micro API."""
+from __future__ import absolute_import, print_function
+
+import sqlalchemy
+from celery import shared_task
+from invenio_db import db
+from invenio_records_files.api import Record
+from invenio_records_files.models import RecordsBuckets
+
+
+@shared_task(ignore_result=True)
+def update_record_files_by_bucket(bucket_id):
+    """Given a bucket id, dump its files in the record metadata."""
+    record_bucket = \
+        RecordsBuckets.query.filter_by(bucket_id=bucket_id).first()
+    if record_bucket:
+        try:
+            record = Record.get_record(record_bucket.record_id)
+            record.files.flush()
+            record.commit()
+            db.session.commit()
+        except sqlalchemy.orm.exc.StaleDataError:
+            # it might fail with `sqlalchemy.orm.exc.StaleDataError`
+            # if another task is updating the record at the same time.
+            # The exception might be ignored because one of the task will
+            # anyway update the record metadata with the entire content
+            # of the bucket.
+            pass
+
+
+def update_record_files_async(object_version):
+    """Get the bucket id and spawn a task to update record metadata."""
+    # convert to string to be able to serialize it when sending to the task
+    str_uuid = str(object_version.bucket_id)
+    return update_record_files_by_bucket.delay(bucket_id=str_uuid)


### PR DESCRIPTION
This adds API support for file attachment uploads/downloads/listing

Permissions on Files REST API endpoints are defined as:

- Everyone can list public records attachments only
- Record owners can CRUD owned record's attachments
- Any other Files API action requires admin role

Periodic checksum checks of attachments are added to Celerybeat schedule

Related: [cesnet-demo-ui#20](https://github.com/oarepo/cesnet-demo-ui/issues/20)